### PR TITLE
Corrected assessed_objects attribute name

### DIFF
--- a/assess/v3/baseline/object-assessment.d.ts
+++ b/assess/v3/baseline/object-assessment.d.ts
@@ -5,7 +5,7 @@ import { AssessedObject } from './assessed-object';
  *  This object is an Unfetter Stix extension
  */
 export declare class ObjectAssessment extends Stix {
-    assessments_objects: AssessedObject[];
+    assessed_objects: AssessedObject[];
     object_ref: string;
     /**
      * @description generate an object with default fields for this type

--- a/assess/v3/baseline/object-assessment.mock.js
+++ b/assess/v3/baseline/object-assessment.mock.js
@@ -25,7 +25,7 @@ var ObjectAssessmentMock = /** @class */ (function (_super) {
         var tmp = new object_assessment_1.ObjectAssessment();
         tmp.id = this.genId(stix_enum_1.StixEnum.OBJECT_ASSESSMENT);
         tmp.created_by_ref = this.genId(stix_core_enum_1.StixCoreEnum.IDENTITY);
-        tmp.assessments_objects = assessed_object_mock_1.AssessedObjectMockFactory.mockMany(3);
+        tmp.assessed_objects = assessed_object_mock_1.AssessedObjectMockFactory.mockMany(3);
         tmp.object_ref = capability_mock_1.CapabilityMockFactory.mockOne(capabilityName).id || '';
         return tmp;
     };

--- a/assess/v3/baseline/object-assessment.spec.js
+++ b/assess/v3/baseline/object-assessment.spec.js
@@ -27,7 +27,7 @@ describe('object assessment model', function () {
     });
     it('should contain assessed objects', function () {
         expect(cut).toBeDefined();
-        expect(cut.assessments_objects).toBeDefined();
-        expect(cut.assessments_objects.length).toBeGreaterThanOrEqual(2);
+        expect(cut.assessed_objects).toBeDefined();
+        expect(cut.assessed_objects.length).toBeGreaterThanOrEqual(2);
     });
 });

--- a/src/assess/v3/baseline/object-assessment.mock.ts
+++ b/src/assess/v3/baseline/object-assessment.mock.ts
@@ -10,7 +10,7 @@ export class ObjectAssessmentMock extends Mock<ObjectAssessment> {
         const tmp = new ObjectAssessment();
         tmp.id = this.genId(StixEnum.OBJECT_ASSESSMENT);
         tmp.created_by_ref = this.genId(StixCoreEnum.IDENTITY);
-        tmp.assessments_objects = AssessedObjectMockFactory.mockMany(3);
+        tmp.assessed_objects = AssessedObjectMockFactory.mockMany(3);
         tmp.object_ref = CapabilityMockFactory.mockOne(capabilityName).id || '';
         return tmp;
     }

--- a/src/assess/v3/baseline/object-assessment.spec.ts
+++ b/src/assess/v3/baseline/object-assessment.spec.ts
@@ -34,8 +34,8 @@ describe('object assessment model', () => {
 
     it('should contain assessed objects', () => {
         expect(cut).toBeDefined();
-        expect(cut.assessments_objects).toBeDefined();
-        expect(cut.assessments_objects.length).toBeGreaterThanOrEqual(2);
+        expect(cut.assessed_objects).toBeDefined();
+        expect(cut.assessed_objects.length).toBeGreaterThanOrEqual(2);
     });
 
 });

--- a/src/assess/v3/baseline/object-assessment.ts
+++ b/src/assess/v3/baseline/object-assessment.ts
@@ -8,7 +8,7 @@ import { AssessedObject } from './assessed-object';
  */
 export class ObjectAssessment extends Stix {
     // AssessedObject has a attack pattern ids
-    public assessments_objects: AssessedObject[];
+    public assessed_objects: AssessedObject[];
     // object ref is a capability id
     public object_ref: string;
 


### PR DESCRIPTION
Fixes unfetter-discover/stix#1166

Renames the assessments_objects attribute of ObjectAssessment to assessed_objects - the correct name of this attribute.