### PR TITLE
Mock values between 0 and 1 to simulate valid risk values

### DIFF
--- a/assess/v2/assessed-by-attack-pattern.mock.js
+++ b/assess/v2/assessed-by-attack-pattern.mock.js
@@ -23,7 +23,7 @@ var AssessedByAttackPatternMock = /** @class */ (function (_super) {
     AssessedByAttackPatternMock.prototype.mockOne = function () {
         var tmp = new assessed_by_attack_pattern_1.AssessedByAttackPattern();
         tmp._id = this.genId();
-        tmp.risk = Math.random() * 100;
+        tmp.risk = Math.random();
         return tmp;
     };
     return AssessedByAttackPatternMock;

--- a/src/assess/v2/assessed-by-attack-pattern.mock.ts
+++ b/src/assess/v2/assessed-by-attack-pattern.mock.ts
@@ -8,7 +8,7 @@ export class AssessedByAttackPatternMock extends Mock<AssessedByAttackPattern> {
     public mockOne(): AssessedByAttackPattern {
         const tmp = new AssessedByAttackPattern();
         tmp._id = this.genId();
-        tmp.risk = Math.random() * 100;
+        tmp.risk = Math.random();
         return tmp;
     }
 }


### PR DESCRIPTION
This is required to fix unfetter-discover/unfetter#1073, and is a base for pull request unfetter-discover/unfetter#671.

Needed to ensure random risk values fall within the acceptable 0 and 1 boundaries.